### PR TITLE
Wrapper select options.

### DIFF
--- a/cpt-lister.php
+++ b/cpt-lister.php
@@ -11,6 +11,8 @@ License: GPLv2
 class cpt_lister {
 	public function cpt_list_this( $atts, $content = "" ) {
 
+		$valid_wrappers = array('h1','h2','h3','h4','h4','h6','li','span','div');
+
 		extract( 
 			shortcode_atts( 
 				array( 
@@ -24,7 +26,7 @@ class cpt_lister {
 				'cptl_title_link_class' => 'cptl_title_link',
 				'cptl_title_class' => 'cptl_title',
 				'cptl_content_class' => 'cptl_content',
-				'cptl_content_wrapper' => 'cptl_wrapper'
+				'cptl_content_wrapper' => 'h1'
 				), $atts 
 			)
 		);
@@ -32,6 +34,10 @@ class cpt_lister {
 		if ( strpos( $post_status, "," ) ) { $post_status = explode(",", $post_status); }
 
 		if ( !empty( $type ) ) {
+
+			if ( empty( $cptl_content_wrapper ) || !in_array($cptl_content_wrapper, $valid_wrappers) ) {
+				$cptl_content_wrapper = 'h1';
+			}
 
 			$args = array(
 			  'post_type' => $type,
@@ -44,9 +50,12 @@ class cpt_lister {
 			$listing_query = null;
 			$listing_query = new WP_Query( $args );
 			if ( $listing_query->have_posts() ) {
+				if ($cptl_content_wrapper === 'li') {
+					echo "<ul>";
+				}
 				while ( $listing_query->have_posts() ) : $listing_query->the_post(); ?>
 
-				<h1 class="<?php echo $cptl_title_class ?>">
+				<<?php echo $cptl_content_wrapper ?> class="<?php echo $cptl_title_class ?>">
 
 			    <?php // Posts TITLES //
 			    if ( $titles_as_links == 1 ) :
@@ -61,7 +70,7 @@ class cpt_lister {
 				<?php the_title(); ?>
 
 			    <?php endif; ?>
-			    </h1>
+			    </<?php echo $cptl_content_wrapper ?>>
 
 			    <?php // Posts CONTENT //
 			    if ( $show_post_content == 1 ) :
@@ -73,6 +82,10 @@ class cpt_lister {
 
 		    	<?php
 			 	endwhile;
+
+			 	if ($cptl_content_wrapper === 'li') {
+					echo "</ul>";
+				}
 			}
 			wp_reset_query();
 

--- a/cpt-lister.php
+++ b/cpt-lister.php
@@ -23,7 +23,8 @@ class cpt_lister {
 				'show_post_content' => 1,
 				'cptl_title_link_class' => 'cptl_title_link',
 				'cptl_title_class' => 'cptl_title',
-				'cptl_content_class' => 'cptl_content'
+				'cptl_content_class' => 'cptl_content',
+				'cptl_content_wrapper' => 'cptl_wrapper'
 				), $atts 
 			)
 		);
@@ -44,20 +45,23 @@ class cpt_lister {
 			$listing_query = new WP_Query( $args );
 			if ( $listing_query->have_posts() ) {
 				while ( $listing_query->have_posts() ) : $listing_query->the_post(); ?>
-			    
+
+				<h1 class="<?php echo $cptl_title_class ?>">
+
 			    <?php // Posts TITLES //
-			    if ( $titles_as_links == 1 ) : 
+			    if ( $titles_as_links == 1 ) :
 			    ?>
 
-			    <a href="<?php the_permalink() ?>" class="<?php echo $cptl_title_link_class; ?>" >
-			    	<h1 class="<?php echo $cptl_title_class ?>"><?php the_title(); ?></h1>
-			    </a>
+		        <a href="<?php the_permalink() ?>" class="<?php echo $cptl_title_link_class; ?>" >
+		    	    <?php the_title(); ?>
+		        </a>
 
 			    <?php else : ?>
 
-			    <h1 class="<?php echo $cptl_title_class ?>"><?php the_title(); ?></h1>
+				<?php the_title(); ?>
 
 			    <?php endif; ?>
+			    </h1>
 
 			    <?php // Posts CONTENT //
 			    if ( $show_post_content == 1 ) :

--- a/cpt-lister.php
+++ b/cpt-lister.php
@@ -42,7 +42,7 @@ class cpt_lister {
 			$args = array(
 			  'post_type' => $type,
 			  'post_status' => $post_status,
-			  'order_by' => $order_by,
+			  'orderby' => $order_by,
 			  'order' => $order,
 			  'posts_per_page' => $posts_per_page
 			  );


### PR DESCRIPTION
I wanted to display the output as a true list so I added a new shortcode attribute to allow the user to specify the wrapper type. I added options for the full range of h1-h6, li, span, and div. When outputting as li, it wraps the whole set in the appropriate ul tag.

I tested this with my live site, so take a look at the list output: http://beer.thegremlyn.com/home-brew-recipes/

One other note: I moved the content wrapper outside of the anchor tag as it makes more sense in this context (ultimately in html5 it doesn't matter, it used to be that the anchor had to be inside the header tag). This allows calling the wrapper tag just once and the content inside the wrapper changes as needed, instead of duplicating the wrapper based on needing a link or not.
